### PR TITLE
Feature/attack cheap mcts

### DIFF
--- a/src/main/java/GameSimulator.java
+++ b/src/main/java/GameSimulator.java
@@ -1,4 +1,5 @@
 import agents.leeroy.Leeroy;
+import at.ac.tuwien.ifs.sge.agent.mctsagent.MctsAgent;
 import at.ac.tuwien.ifs.sge.agent.randomagent.RandomAgent;
 import util.command.MockedMatchCommand;
 
@@ -11,22 +12,14 @@ public class GameSimulator {
     public static void main(String[] args) throws Exception {
         logger.info("Starting simulation..");
 
-        // note: no multithreading on my pc :-(
-        for (int i = 1; i<= 10; i++) {
-            int finalI = i;
-            new Thread(() -> {
-                try {
-                    MockedMatchCommand mCmd = new MockedMatchCommand(String.format("GameRun_%02d", finalI));
-                    mCmd.setEvaluatedAgent(Leeroy.class);
-                    mCmd.setOpponentAgent(RandomAgent.class);
-                    mCmd.showMapOutput(false);
 
-                    // start
-                    mCmd.run();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }).run();
-        }
+        MockedMatchCommand mCmd = new MockedMatchCommand(String.format("GameRun_%02d", 1));
+        mCmd.setEvaluatedAgent(Leeroy.class);
+        mCmd.setOpponentAgent(RandomAgent.class);
+        mCmd.showMapOutput(false);
+
+        // start
+        mCmd.run();
+        System.exit(0);
     }
 }

--- a/src/main/java/agents/leeroy/AttackActionSupplier.java
+++ b/src/main/java/agents/leeroy/AttackActionSupplier.java
@@ -15,10 +15,12 @@ public class AttackActionSupplier {
         final Set<Integer> sourceTerritoryIds = risk
                 .getBoard()
                 .getTerritoriesOccupiedByPlayer(risk.getCurrentPlayer());
-        return sourceTerritoryIds
+        var attackActions = sourceTerritoryIds
               .stream()
               .flatMap(tId -> AttackActionSupplier.createActions(risk, tId).stream())
               .collect(Collectors.toSet());
+        attackActions.add(RiskAction.endPhase());
+        return attackActions;
     }
 
     private static Set<RiskAction> createActions(Risk risk, Integer srcTerritoryId) {

--- a/src/main/java/agents/leeroy/AttackActionSupplier.java
+++ b/src/main/java/agents/leeroy/AttackActionSupplier.java
@@ -1,0 +1,50 @@
+package agents.leeroy;
+
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AttackActionSupplier {
+
+    private static final double RISK_THRESHOLD = 0.5;
+
+    public static Set<RiskAction> createActions(Risk risk) {
+        final Set<Integer> sourceTerritoryIds = risk
+                .getBoard()
+                .getTerritoriesOccupiedByPlayer(risk.getCurrentPlayer());
+        return sourceTerritoryIds
+              .stream()
+              .flatMap(tId -> AttackActionSupplier.createActions(risk, tId).stream())
+              .collect(Collectors.toSet());
+    }
+
+    private static Set<RiskAction> createActions(Risk risk, Integer srcTerritoryId) {
+        final Set<Integer> targetTerritoryIds = risk
+                .getBoard()
+                .neighboringEnemyTerritories(srcTerritoryId);
+        return targetTerritoryIds
+                .stream()
+                .flatMap(tId -> AttackActionSupplier.createActions(risk, srcTerritoryId, tId).stream())
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * atm only full-attack is considered
+     * @param risk
+     * @param srcTerritoryId
+     * @param targetTerritoryId
+     * @return
+     */
+    private static Set<RiskAction> createActions(Risk risk, Integer srcTerritoryId, Integer targetTerritoryId) {
+        final int maxAttackTroops = risk.getBoard().getMaxAttackingTroops(srcTerritoryId);
+        final int defenderTroops = risk.getBoard().getTerritoryTroops(targetTerritoryId);
+
+        if (BattleSimulator.getWinProbability(maxAttackTroops, defenderTroops) >= RISK_THRESHOLD) {
+            return Set.of(RiskAction.attack(srcTerritoryId, targetTerritoryId, maxAttackTroops));
+        }
+        return Set.of();
+    }
+}

--- a/src/main/java/agents/leeroy/AttackNode.java
+++ b/src/main/java/agents/leeroy/AttackNode.java
@@ -1,0 +1,68 @@
+package agents.leeroy;
+
+import at.ac.tuwien.ifs.sge.game.Game;
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class AttackNode implements Node {
+
+    private final int player;
+    private final Node parent;
+    private final Risk game;
+    private List<Node> successors = null;
+    private double winScore;
+    private int visitCount = 0;
+
+    @Override
+    public List<Node> getSuccessors() {
+        if (successors == null) {
+            successors = AttackActionSupplier
+                    .createActions(game)
+                    .stream()
+                    .map(ra -> new AttackNode(player, this, (Risk) game.doAction(ra)))
+                    .collect(Collectors.toList());
+        }
+
+        return successors;
+    }
+
+    @Override
+    public boolean isLeafNode() {
+        return getSuccessors().isEmpty();
+    }
+
+    @Override
+    public int getId() {
+        return 0;
+    }
+
+    @Override
+    public Optional<Node> getParent() {
+        if (parent == null) {
+            return Optional.empty();
+        }
+        return Optional.of(this.parent);
+    }
+
+    @Override
+    public void incrementVisitCount() {
+        visitCount += 1;
+    }
+
+    @Override
+    public void incrementWinScore(double increment) {
+        winScore += increment;
+    }
+
+    @Override
+    public boolean isExpanded() {
+        return successors != null;
+    }
+}

--- a/src/main/java/agents/leeroy/BattleSimulator.java
+++ b/src/main/java/agents/leeroy/BattleSimulator.java
@@ -1,0 +1,46 @@
+package agents.leeroy;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * based on https://www4.stat.ncsu.edu/~jaosborn/research/RISK.pdf
+ */
+public class BattleSimulator {
+
+    private final static List<? extends List<? extends Number>> smallBattleProbabilities = Arrays.asList(
+            Arrays.asList(0.417, 0.106, 0.027, 0.007, 0.002, 0, 0, 0, 0, 0, 0),
+            Arrays.asList(0.754, 0.363, 0.206, 0.091, 0.049, 0.021, 0.011, 0.005, 0.003, 0.001),
+            Arrays.asList(0.916, 0.656, 0.47, 0.315, 0.206, 0.134, 0.084, 0.054, 0.033, 0.021),
+            Arrays.asList(0.972, 0.785, 0.642, 0.477, 0.359, 0.253, 0.181, 0.123, 0.086, 0.057),
+            Arrays.asList(0.990, 0.890, 0.769, 0.638, 0.506, 0.397, 0.297, 0.224, 0.162, 0.118),
+            Arrays.asList(0.997, 0.934, 0.857, 0.745, 0.638, 0.521, 0.423, 0.329, 0.258, 0.193),
+            Arrays.asList(0.999, 0.967, 0.91, 0.834, 0.736, 0.64, 0.536, 0.446, 0.357, 0.287),
+            Arrays.asList(1, 0.98, 0.947, 0.888, 0.818, 0.73, 0.643, 0.547, 0.464, 0.38),
+            Arrays.asList(1, 0.99, 0.967, 0.93, 0.873, 0.808, 0.726, 0.646, 0.558, 0.48),
+            Arrays.asList(1, 0.994, 0.981, 0.954, 0.916, 0.861, 0.8, 0.724, 0.65, 0.568)
+    );
+
+    public static double getWinProbability(int attackTroops, int defendTroops) {
+        if (attackTroops < 1) {
+            return 0;
+        } else if (defendTroops < 1) {
+            return 1;
+        }
+
+        if (attackTroops < 11 && defendTroops < 11) {
+            return (double) smallBattleProbabilities.get(attackTroops-1).get(defendTroops-1);
+        }
+
+        // stupid heuristic which needs to be revised maybe
+        // based on https://boardgames.stackexchange.com/questions/3514/how-can-i-estimate-my-chances-to-win-a-risk-battle
+        final double expectedLossDef = 1.08;
+        final double expectedLossAtt = 0.922;
+        if ((attackTroops / expectedLossAtt) > (defendTroops / expectedLossDef)) {
+            return getWinProbability(10, (int) Math.floor((attackTroops - 10) / expectedLossAtt * defendTroops));
+        }
+
+        return getWinProbability((int)Math.floor ((defendTroops - 10) / expectedLossDef * attackTroops), 10);
+    }
+
+}

--- a/src/main/java/agents/leeroy/BattleSimulator.java
+++ b/src/main/java/agents/leeroy/BattleSimulator.java
@@ -9,16 +9,16 @@ import java.util.List;
 public class BattleSimulator {
 
     private final static List<? extends List<? extends Number>> smallBattleProbabilities = Arrays.asList(
-            Arrays.asList(0.417, 0.106, 0.027, 0.007, 0.002, 0, 0, 0, 0, 0, 0),
+            Arrays.asList(0.417, 0.106, 0.027, 0.007, 0.002, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
             Arrays.asList(0.754, 0.363, 0.206, 0.091, 0.049, 0.021, 0.011, 0.005, 0.003, 0.001),
             Arrays.asList(0.916, 0.656, 0.47, 0.315, 0.206, 0.134, 0.084, 0.054, 0.033, 0.021),
             Arrays.asList(0.972, 0.785, 0.642, 0.477, 0.359, 0.253, 0.181, 0.123, 0.086, 0.057),
             Arrays.asList(0.990, 0.890, 0.769, 0.638, 0.506, 0.397, 0.297, 0.224, 0.162, 0.118),
             Arrays.asList(0.997, 0.934, 0.857, 0.745, 0.638, 0.521, 0.423, 0.329, 0.258, 0.193),
             Arrays.asList(0.999, 0.967, 0.91, 0.834, 0.736, 0.64, 0.536, 0.446, 0.357, 0.287),
-            Arrays.asList(1, 0.98, 0.947, 0.888, 0.818, 0.73, 0.643, 0.547, 0.464, 0.38),
-            Arrays.asList(1, 0.99, 0.967, 0.93, 0.873, 0.808, 0.726, 0.646, 0.558, 0.48),
-            Arrays.asList(1, 0.994, 0.981, 0.954, 0.916, 0.861, 0.8, 0.724, 0.65, 0.568)
+            Arrays.asList(1.0, 0.98, 0.947, 0.888, 0.818, 0.73, 0.643, 0.547, 0.464, 0.38),
+            Arrays.asList(1.0, 0.99, 0.967, 0.93, 0.873, 0.808, 0.726, 0.646, 0.558, 0.48),
+            Arrays.asList(1.0, 0.994, 0.981, 0.954, 0.916, 0.861, 0.8, 0.724, 0.65, 0.568)
     );
 
     public static double getWinProbability(int attackTroops, int defendTroops) {
@@ -37,10 +37,10 @@ public class BattleSimulator {
         final double expectedLossDef = 1.08;
         final double expectedLossAtt = 0.922;
         if ((attackTroops / expectedLossAtt) > (defendTroops / expectedLossDef)) {
-            return getWinProbability(10, (int) Math.floor((attackTroops - 10) / expectedLossAtt * defendTroops));
+            return getWinProbability(10, (int) Math.floor(defendTroops - (attackTroops - 10) / expectedLossAtt * expectedLossDef));
         }
 
-        return getWinProbability((int)Math.floor ((defendTroops - 10) / expectedLossDef * attackTroops), 10);
+        return getWinProbability((int)Math.floor (attackTroops - (defendTroops - 10) / expectedLossDef * expectedLossAtt), 10);
     }
 
 }

--- a/src/main/java/agents/leeroy/Leeroy.java
+++ b/src/main/java/agents/leeroy/Leeroy.java
@@ -31,10 +31,11 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         super.setTimers(computationTime, timeUnit);
         log.info("Computing action");
         Risk risk = (Risk) game;
-        // @anton TODO: change to v1.0.1 game.getBoard.is__Phase() ??
         setPhase(risk);
         if (currentPhase == Phase.INITIAL_SELECT) {
             return (A) selectInitialCountry(risk);
+        } else if (game.getBoard().isAttackPhase()) {
+            return (A) attackTerritory(risk);
         }
         return (A) Util.selectRandom(risk.getPossibleActions());
     }
@@ -71,6 +72,11 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         //Graph moved one node forward after the action
         initialPlacementRoot = bestNode;
         return RiskAction.select(bestNode.getId());
+    }
+
+    private RiskAction attackTerritory(Risk risk) {
+        // TODO: MCTS
+        return Util.selectRandom(AttackActionSupplier.createActions(risk));
     }
 
     private void setNewInitialPlacementRoot(Risk game) {


### PR DESCRIPTION
Adds a simplified filter for attack actions:

- Win-Probability must be >= 0.5 (see BattleSimulator.java)
- All moveable troops are used at each attack

From this pool of possible actions the chosen actions are still selected randomly.
Example run where agent performed very well against random agent:
[img_run_fa_random.zip](https://github.com/AntonOellerer/risk_crusher/files/5540538/img_run_fa_random.zip)
Example run where agent was not able to conquer Australia (bc of missing move/fortify logic) 
[img_run_fa_random_aust_stall.zip](https://github.com/AntonOellerer/risk_crusher/files/5540542/img_run_fa_random_aust_stall.zip)

Important here are the backup_troops.pdf files which show that a high number of troops is used inefficiently. Our next target should be to improve this imo.

Possible extension points for attack action selection include:

- MCTS for action selection (+ many different heuristics)
- Addition of rule which optimizes for attrition. I.e for battles with more than 10 troops the attacker is expected to have fewer losses than the defender. When optimizing for troop size it therefor always makes sense to attack (even if the number of attacking armies is smaller than the number of defending armies) -> This would mean extending the AttackActionSupplier.java methods for such scenarios.

