### PR TITLE
Feature/mcts attack occupy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,39 +74,39 @@
             <groupId>at.ac.tuwien.ifs.sge</groupId>
             <artifactId>sge</artifactId>
             <version>1.0.1</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <!-- risk specifics -->
             <groupId>at.ac.tuwien.ifs.sge</groupId>
             <artifactId>sge-risk</artifactId>
             <version>1.0.1</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
         </dependency>
-<!--        <dependency>-->
-<!--            &lt;!&ndash; random agent &ndash;&gt;-->
-<!--            <groupId>at.ac.tuwien</groupId>-->
-<!--            <artifactId>risk-random-agent</artifactId>-->
-<!--            <version>1.0</version>-->
-<!--            <scope>system</scope>-->
-<!--            <systemPath>${project.basedir}/lib/sge-randomagent-1.0.0.jar</systemPath>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            &lt;!&ndash; alphabeta agent &ndash;&gt;-->
-<!--            <groupId>at.ac.tuwien</groupId>-->
-<!--            <artifactId>risk-alphabeta-agent</artifactId>-->
-<!--            <version>1.0</version>-->
-<!--            <scope>system</scope>-->
-<!--            <systemPath>${project.basedir}/lib/sge-alphabetaagent-1.0.0.jar</systemPath>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            &lt;!&ndash; mcts agent &ndash;&gt;-->
-<!--            <groupId>at.ac.tuwien</groupId>-->
-<!--            <artifactId>risk-mcts-agent</artifactId>-->
-<!--            <version>1.0</version>-->
-<!--            <scope>system</scope>-->
-<!--            <systemPath>${project.basedir}/lib/sge-mctsagent-1.0.0.jar</systemPath>-->
-<!--        </dependency>-->
+        <dependency>
+            <!-- random agent -->
+            <groupId>at.ac.tuwien</groupId>
+            <artifactId>risk-random-agent</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/sge-randomagent-1.0.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <!-- alphabeta agent -->
+            <groupId>at.ac.tuwien</groupId>
+            <artifactId>risk-alphabeta-agent</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/sge-alphabetaagent-1.0.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <!-- mcts agent -->
+            <groupId>at.ac.tuwien</groupId>
+            <artifactId>risk-mcts-agent</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/sge-mctsagent-1.0.0.jar</systemPath>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/src/main/java/GameSimulator.java
+++ b/src/main/java/GameSimulator.java
@@ -1,4 +1,8 @@
+import at.ac.tuwien.ifs.sge.agent.alphabetaagent.AlphaBetaAgent;
+import at.ac.tuwien.ifs.sge.agent.mctsagent.MctsAgent;
+import at.ac.tuwien.ifs.sge.agent.randomagent.RandomAgent;
 import at.ac.tuwien.ifs.sge.leeroy.agents.Leeroy;
+import at.ac.tuwien.ifs.sge.leeroy.agents.LeeroyMctsAttack;
 import at.ac.tuwien.ifs.sge.leeroy.util.command.MockedMatchCommand;
 
 import java.util.logging.Logger;
@@ -10,15 +14,17 @@ public class GameSimulator {
     public static void main(String[] args) throws Exception {
         logger.info("Starting simulation..");
 
+        for (int i = 1; i< 11; i++) {
+            System.out.println(String.format("Performing run %d", i));
+            MockedMatchCommand mCmd = new MockedMatchCommand(String.format("GameRun_%02d", i));
+            mCmd.setEvaluatedAgent(LeeroyMctsAttack.class);
+            mCmd.setOpponentAgent(AlphaBetaAgent.class);
+            mCmd.showMapOutput(false);
+            mCmd.setComputationTime(15l); // max seconds per turn
 
-        MockedMatchCommand mCmd = new MockedMatchCommand(String.format("GameRun_%02d", 1));
-        mCmd.setEvaluatedAgent(Leeroy.class);
-        mCmd.setOpponentAgent(Leeroy.class);
-        mCmd.showMapOutput(false);
-        mCmd.setComputationTime(30l); // max seconds per turn
-
-        // start
-        mCmd.run();
+            // start
+            mCmd.run();
+        }
         System.exit(0);
     }
 }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/BattleSimulator.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/BattleSimulator.java
@@ -37,10 +37,12 @@ public class BattleSimulator {
         final double expectedLossDef = 1.08;
         final double expectedLossAtt = 0.922;
         if ((attackTroops / expectedLossAtt) > (defendTroops / expectedLossDef)) {
-            return getWinProbability(10, (int) Math.floor(defendTroops - (attackTroops - 10) / expectedLossAtt * expectedLossDef));
+            int targetV = attackTroops == 10 ? 9 : 10;
+            return getWinProbability(targetV, (int) Math.floor(defendTroops - (attackTroops - targetV) / expectedLossAtt * expectedLossDef));
         }
 
-        return getWinProbability((int)Math.floor (attackTroops - (defendTroops - 10) / expectedLossDef * expectedLossAtt), 10);
+        int targetV = defendTroops == 10 ? 9 : 10;
+        return getWinProbability((int)Math.floor (attackTroops - (defendTroops - targetV) / expectedLossDef * expectedLossAtt), targetV);
     }
 
 }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/BattleSimulator.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/BattleSimulator.java
@@ -22,9 +22,9 @@ public class BattleSimulator {
     );
 
     public static double getWinProbability(int attackTroops, int defendTroops) {
-        if (attackTroops < 1) {
+        if (attackTroops < 1 || (defendTroops / attackTroops * 1.0 > 10)) {
             return 0;
-        } else if (defendTroops < 1) {
+        } else if (defendTroops < 1 || (attackTroops / defendTroops * 1.0 > 10)) {
             return 1;
         }
 

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
@@ -117,6 +117,34 @@ public class GameUtils {
         return neighbors;
     }
 
+    public static Set<Integer> getEnemyNeighbors(Set<Integer> territoriesOccupiedByPlayer, RiskBoard riskBoard) {
+        Set<Integer> neighbors = new HashSet<>();
+        for (Integer territory : territoriesOccupiedByPlayer) {
+            neighbors.addAll(riskBoard.neighboringEnemyTerritories(territory));
+        }
+        return neighbors;
+    }
+
+    public static int getFrontlineMargin(Set<Integer> territoriesOccupiedByPlayer, RiskBoard riskBoard) {
+        Set<Integer> neighbors = new HashSet<>();
+        int margin = 0;
+        for (Integer territory : territoriesOccupiedByPlayer) {
+            Set<Integer> territoryNeighbors = riskBoard.neighboringEnemyTerritories(territory);
+            if (territoryNeighbors.isEmpty()) {
+                continue;
+            }
+            margin += riskBoard.getTerritoryTroops(territory); // add troops of player's territory
+            for (Integer enemyTerritory : territoryNeighbors) {
+                if (neighbors.contains(enemyTerritory)) {
+                    continue;
+                }
+                margin -= riskBoard.getTerritoryTroops(enemyTerritory); // subtract troops of new enemy's territory
+                neighbors.add(enemyTerritory);
+            }
+        }
+        return margin;
+    }
+
     private static Set<Integer> getContinentsOccupied(Set<Integer> territoriesOccupiedByPlayer, RiskBoard riskBoard) {
         Set<Integer> continents = new HashSet<>();
         for (Integer territory : territoriesOccupiedByPlayer) {
@@ -139,7 +167,7 @@ public class GameUtils {
         return totalMalus;
     }
 
-    private static int getContinentBonusForPlayer(int player, RiskBoard riskBoard) {
+    public static int getContinentBonusForPlayer(int player, RiskBoard riskBoard) {
         if (continentTerritories == null) {
             continentTerritories = getContinentTerritories(riskBoard);
         }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
@@ -125,6 +125,16 @@ public class GameUtils {
         return neighbors;
     }
 
+    public static int getUnusedTroops(Set<Integer> territoriesOccupiedByPlayer, RiskBoard riskBoard) {
+        int unusedTroopSum = 0;
+        for (Integer territory : territoriesOccupiedByPlayer) {
+            if (riskBoard.neighboringEnemyTerritories(territory).isEmpty()) {
+                unusedTroopSum += riskBoard.getMobileTroops(territory);
+            }
+        }
+        return unusedTroopSum;
+    }
+
     public static int getFrontlineMargin(Set<Integer> territoriesOccupiedByPlayer, RiskBoard riskBoard) {
         Set<Integer> neighbors = new HashSet<>();
         int margin = 0;
@@ -157,7 +167,7 @@ public class GameUtils {
         return getContinentBonusForPlayer(playerId, riskBoard);
     }
 
-    private static int getTotalContinentMalus(int playerId, RiskBoard riskBoard) {
+    public static int getTotalContinentMalus(int playerId, RiskBoard riskBoard) {
         int totalMalus = 0;
         for (int i = 0; i < riskBoard.getNumberOfPlayers(); i++) {
             if (i != playerId) {

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
@@ -32,6 +32,10 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
     @Override
     public A computeNextAction(G game, long computationTime, TimeUnit timeUnit) {
         super.setTimers(computationTime, timeUnit);
+
+        // :-( other agents might influence ours
+        System.gc();
+
         log.info("Computing action");
         Risk risk = (Risk) game;
         A nextAction;

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G, A> implements GameAgent<G, A> {
 
-    private final int INITIAL_SELECT_TIMEOUT_PENALTY = 1000;
+    private final int INITIAL_SELECT_TIMEOUT_PENALTY = 10000000;
     Phase currentPhase = Phase.INITIAL_SELECT;
     Node initialPlacementRoot;
     private int playerNumber;
@@ -45,8 +45,7 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
             } else if (game.getBoard().isAttackPhase()) {
                 nextAction = (A) attackTerritory(risk);
             } else if (game.getBoard().isOccupyPhase()) {
-                // TODO: improve occupy - atm all troops are moved
-                nextAction = (A) RiskAction.occupy(game.getPossibleActions().size());
+                nextAction = (A) occupyTerritory(risk);
             } else if (game.getBoard().isFortifyPhase()) {
                 nextAction = (A) fortifyTerritory(risk);
             } else {
@@ -54,6 +53,10 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
             }
         } catch(Exception e) {
             e.printStackTrace();
+            nextAction = (A) Util.selectRandom(risk.getPossibleActions());
+        }
+        if (nextAction == null) {
+            log.err("No action; state " + currentPhase + "; " + game );
             nextAction = (A) Util.selectRandom(risk.getPossibleActions());
         }
         if (! game.isValidAction(nextAction)) {
@@ -108,9 +111,8 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         return node.getSuccessors().stream().max(Comparator.comparingDouble(Node::getWinScore)).get();
     }
 
-    private RiskAction attackTerritory(Risk risk) {
-        // TODO: MCTS
-        Set<RiskAction> attackActions = AttackActionSupplier.createActions(risk);
+    protected RiskAction attackTerritory(Risk risk) {
+        Set<RiskAction> attackActions = AttackActionSupplier.createActions(risk, null);
         Optional<RiskAction> highAtkAction = attackActions
                 .stream()
                 .sorted(Comparator.comparingInt(action -> action.troops() *-1))
@@ -120,6 +122,10 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
             return RiskAction.attack(atkAction.attackingId(), atkAction.defendingId(), Math.min(3, atkAction.troops()));
         }
         return RiskAction.endPhase();
+    }
+
+    protected RiskAction occupyTerritory(Risk risk) {
+        return RiskAction.occupy(risk.getPossibleActions().size());
     }
 
     private RiskAction fortifyTerritory(Risk risk) {

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
@@ -15,8 +15,8 @@ public class LeeroyMctsAttack extends Leeroy {
 
     // TODO: store/reuse search tree from previous mcts runs
 
-    private final int ATTACK_TIMEOUT_PENALTY = 10;
-    private final int OCCUPY_TIMEOUT_PENALTY = 50;
+    private final int ATTACK_TIMEOUT_PENALTY = 1;
+    private final int OCCUPY_TIMEOUT_PENALTY = 2;
 
     public LeeroyMctsAttack(Logger log) {
         super(log);

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
@@ -1,0 +1,42 @@
+package at.ac.tuwien.ifs.sge.leeroy.agents;
+
+import at.ac.tuwien.ifs.sge.engine.Logger;
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.AttackMctsActionSupplier;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.ActionNode;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.MctsActionSupplier;
+import at.ac.tuwien.ifs.sge.util.Util;
+
+/***
+ * extends Leeroy with Mcts Attack/Occupy selection
+ */
+public class LeeroyMctsAttack extends Leeroy {
+
+    // TODO: store/reuse search tree from previous mcts runs
+
+    private final int ATTACK_TIMEOUT_PENALTY = 10;
+    private final int OCCUPY_TIMEOUT_PENALTY = 50;
+
+    public LeeroyMctsAttack(Logger log) {
+        super(log);
+    }
+
+    @Override
+    protected RiskAction attackTerritory(Risk risk) {
+        MctsActionSupplier actionSupplier = new AttackMctsActionSupplier(
+                () -> this.shouldStopComputation(ATTACK_TIMEOUT_PENALTY));
+        actionSupplier.setRootNode(new ActionNode(risk.getCurrentPlayer(), null, risk, null));
+        ActionNode bestNode = actionSupplier.findBestNode();
+        return bestNode != null ? bestNode.getAction() : Util.selectRandom(risk.getPossibleActions());
+    }
+
+    @Override
+    protected RiskAction occupyTerritory(Risk risk) {
+        MctsActionSupplier actionSupplier = new AttackMctsActionSupplier(
+                () -> this.shouldStopComputation(OCCUPY_TIMEOUT_PENALTY));
+        actionSupplier.setRootNode(new ActionNode(risk.getCurrentPlayer(), null, risk, null));
+        ActionNode bestNode = actionSupplier.findBestNode();
+        return bestNode != null ? bestNode.getAction() : Util.selectRandom(risk.getPossibleActions());
+    }
+}

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
@@ -82,12 +82,16 @@ public class OccupyActionSupplier {
                 evaluatedTerritories.add(srcId);
                 Set<Integer> newNeighbors = risk.getBoard().neighboringFriendlyTerritories(srcId);
                 newNeighbors.removeAll(evaluatedTerritories);
+                newNeighbors.removeAll(curLevelTerritories);
                 nextLevelTerritories.addAll(newNeighbors);
             }
             curDistance += 1;
             curLevelTerritories = nextLevelTerritories;
         }
 
+        if (risk.isGameOver()) {
+            return Integer.MAX_VALUE;
+        }
         throw new IllegalStateException("Found disconnected region - illegal risk board");
     }
 }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
@@ -4,6 +4,7 @@ import at.ac.tuwien.ifs.sge.game.ActionRecord;
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class OccupyActionSupplier {
@@ -17,12 +18,13 @@ public class OccupyActionSupplier {
     }
 
     public static Set<RiskAction> createActions(Risk risk, RiskAction attackAction) {
-        Set<RiskAction> possibleActions = risk.getPossibleActions();
         int srcTerritory = attackAction.attackingId();
         int targetTerritory = attackAction.defendingId();
 
-        boolean isSrcSafe = risk.getBoard().neighboringEnemyTerritories(srcTerritory).isEmpty();
-        boolean isTargetSafe = risk.getBoard().neighboringEnemyTerritories(targetTerritory).isEmpty();
+        Set<Integer> srcEnemyNeighbors = risk.getBoard().neighboringEnemyTerritories(srcTerritory);
+        Set<Integer> targetEnemyNeighbors = risk.getBoard().neighboringEnemyTerritories(targetTerritory);
+        boolean isSrcSafe = srcEnemyNeighbors.isEmpty();
+        boolean isTargetSafe = targetEnemyNeighbors.isEmpty();
 
         if (isTargetSafe && ! isSrcSafe) {
             return Set.of(RiskAction.occupy(1)); // min troops
@@ -30,6 +32,62 @@ public class OccupyActionSupplier {
             return Set.of(RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))); // max troops
         }
 
-        return possibleActions; // all troops -> let mcts decide - room for improvements
+        if (isTargetSafe && isSrcSafe) {
+            // if none of the territories is at the frontline - check which is closer
+            int srcFrontlineDistance = getFrontlineDistance(risk, srcTerritory);
+            int targetFrontlineDistance = getFrontlineDistance(risk, targetTerritory);
+
+            if (srcFrontlineDistance < targetFrontlineDistance) {
+                return Set.of(RiskAction.occupy(1)); // min troops
+            } else if (srcFrontlineDistance > targetFrontlineDistance) {
+                return Set.of(RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))); // max troops
+            }
+            // if distance is equal let mcts decide
+            return Set.of(
+                    RiskAction.occupy(1),
+                    RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory)));
+        }
+
+        // both are frontline: evaluate - move all, move min, move according to territory ratio
+        Set<RiskAction> evaluatedActions = new HashSet<>(Set.of(
+                RiskAction.occupy(1),
+                RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))));
+
+        double targetFrontlineTerritoryRatio = targetEnemyNeighbors.size() * 1.0 / (targetEnemyNeighbors.size() + srcEnemyNeighbors.size());
+        long occupyTroops = Math.round(risk.getBoard().getFortifyableTroops(srcTerritory) * targetFrontlineTerritoryRatio);
+        if (occupyTroops > 1) {
+            evaluatedActions.add(RiskAction.occupy((int) occupyTroops));
+        }
+
+        return evaluatedActions; // let mcts decide -> room for improvements
+    }
+
+    /**
+     * returns the distance to the closest frontline territory
+     * @param risk
+     * @param sourceTerritory
+     * @return
+     */
+    private static int getFrontlineDistance(Risk risk, int sourceTerritory) {
+        Set<Integer> curLevelTerritories = Set.of(sourceTerritory);
+        Set<Integer> evaluatedTerritories = new HashSet<>();
+        Set<Integer> nextLevelTerritories;
+        int curDistance = 0;
+        while (!curLevelTerritories.isEmpty()) {
+            nextLevelTerritories = new HashSet<>();
+            for (Integer srcId : curLevelTerritories) {
+                if (! risk.getBoard().neighboringEnemyTerritories(srcId).isEmpty()) {
+                    return curDistance;
+                }
+                evaluatedTerritories.add(srcId);
+                Set<Integer> newNeighbors = risk.getBoard().neighboringFriendlyTerritories(srcId);
+                newNeighbors.removeAll(evaluatedTerritories);
+                nextLevelTerritories.addAll(newNeighbors);
+            }
+            curDistance += 1;
+            curLevelTerritories = nextLevelTerritories;
+        }
+
+        throw new IllegalStateException("Found disconnected region - illegal risk board");
     }
 }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
@@ -1,0 +1,35 @@
+package at.ac.tuwien.ifs.sge.leeroy.agents;
+
+import at.ac.tuwien.ifs.sge.game.ActionRecord;
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+
+import java.util.Set;
+
+public class OccupyActionSupplier {
+
+    public static Set<RiskAction> createActions(Risk risk) {
+        int attackActionId = risk.getNumberOfActions() - 2;
+        ActionRecord attackRecord = risk.getActionRecords().get(attackActionId);
+        RiskAction attackAction = (RiskAction)attackRecord.getAction();
+
+        return createActions(risk, attackAction);
+    }
+
+    public static Set<RiskAction> createActions(Risk risk, RiskAction attackAction) {
+        Set<RiskAction> possibleActions = risk.getPossibleActions();
+        int srcTerritory = attackAction.attackingId();
+        int targetTerritory = attackAction.defendingId();
+
+        boolean isSrcSafe = risk.getBoard().neighboringEnemyTerritories(srcTerritory).isEmpty();
+        boolean isTargetSafe = risk.getBoard().neighboringEnemyTerritories(targetTerritory).isEmpty();
+
+        if (isTargetSafe && ! isSrcSafe) {
+            return Set.of(RiskAction.occupy(1)); // min troops
+        } else if (isSrcSafe && ! isTargetSafe) {
+            return Set.of(RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))); // max troops
+        }
+
+        return possibleActions; // all troops -> let mcts decide - room for improvements
+    }
+}

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/ActionNode.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/ActionNode.java
@@ -1,66 +1,56 @@
-package at.ac.tuwien.ifs.sge.leeroy.agents;
+package at.ac.tuwien.ifs.sge.leeroy.mcts;
 
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
-public class AttackNode implements Node {
+public class ActionNode {
 
     private final int player;
-    private final Node parent;
+    private final ActionNode parent;
     private final Risk game;
-    private List<Node> successors = null;
+    private final RiskAction action;
+    private List<ActionNode> successors = null;
     private double winScore;
     private int visitCount = 0;
 
-    @Override
-    public List<Node> getSuccessors() {
-        if (successors == null) {
-            successors = AttackActionSupplier
-                    .createActions(game)
-                    .stream()
-                    .map(ra -> new AttackNode(player, this, (Risk) game.doAction(ra)))
-                    .collect(Collectors.toList());
-        }
-
+    public List<ActionNode> getSuccessors() {
         return successors;
     }
 
-    @Override
-    public boolean isLeafNode() {
-        return getSuccessors().isEmpty();
+    public void setSuccessors(List<ActionNode> actionNodes) {
+        this.successors = actionNodes;
     }
 
-    @Override
+    public boolean isLeafNode() {
+        return action != null && action.isEndPhase();
+    }
+
     public int getId() {
         return 0;
     }
 
-    @Override
-    public Optional<Node> getParent() {
+    public Optional<ActionNode> getParent() {
         if (parent == null) {
             return Optional.empty();
         }
         return Optional.of(this.parent);
     }
 
-    @Override
     public void incrementVisitCount() {
         visitCount += 1;
     }
 
-    @Override
     public void incrementWinScore(double increment) {
         winScore += increment;
     }
 
-    @Override
     public boolean isExpanded() {
         return successors != null;
     }

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
@@ -1,0 +1,144 @@
+package at.ac.tuwien.ifs.sge.leeroy.mcts;
+
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
+import at.ac.tuwien.ifs.sge.leeroy.agents.AttackActionSupplier;
+import at.ac.tuwien.ifs.sge.leeroy.agents.GameUtils;
+import at.ac.tuwien.ifs.sge.leeroy.agents.OccupyActionSupplier;
+import at.ac.tuwien.ifs.sge.util.Util;
+
+import java.util.*;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class AttackMctsActionSupplier extends MctsActionSupplier{
+
+    /**
+     * magic numbers for optimal action selection
+     */
+    private static final double OCCUPATION_FACTOR = 20; // number of our occupied territories
+    private static final double FRONTLINE_PENALTY_FACTOR = -2; // number of enemy territories on the frontline
+    private static final double FRONTLINE_MARGIN_FACTOR = 0.25; // margin of frontline troops (ours minus theirs)
+    private static final double CONTINENT_BONUS_FACTOR = 100; // bonus for occupied continents
+
+    private final static int MAX_ATTACK_TROOPS = 3;
+
+    public AttackMctsActionSupplier(BooleanSupplier shouldStopComputation) {
+        super(shouldStopComputation);
+    }
+
+    /**
+     * first expand territories with max defending troops -> attacker looses less troops -> maximize expected value
+     * ( i.e. difference of troops lost)
+     * @return
+     */
+    @Override
+    Function<ActionNode, ActionNode> getNodeSelectionFunction() {
+        return (node) -> {
+            RiskBoard board = node.getGame().getBoard();
+
+            return Collections.max(node.getSuccessors(),
+                    Comparator.comparingInt(nodeToEvaluate ->
+                       board.getTerritoryTroops(nodeToEvaluate.getAction().defendingId())
+                    ));
+            };
+    }
+
+    @Override
+    Function<ActionNode, Integer> getEvaluationFunction() {
+        return (node) -> {
+            Risk game = node.getGame();
+            RiskBoard board = game.getBoard();
+            int activePlayer = game.getCurrentPlayer();
+
+            Set<Integer> occupiedTerritories = board.getTerritoriesOccupiedByPlayer(activePlayer);
+            Set<Integer> neighbouringEnemyTerritories = GameUtils.getEnemyNeighbors(occupiedTerritories, board);
+
+            double occupationBonus = occupiedTerritories.size() * OCCUPATION_FACTOR;
+            double frontlineCntMalus = neighbouringEnemyTerritories.size() * FRONTLINE_PENALTY_FACTOR;
+            double frontlineMarginFactor = GameUtils.getFrontlineMargin(occupiedTerritories, board) * FRONTLINE_MARGIN_FACTOR;
+            double continentBonus = GameUtils.getContinentBonusForPlayer(activePlayer, board) * CONTINENT_BONUS_FACTOR;
+
+            return Math.toIntExact(Math.round(occupationBonus + frontlineCntMalus + frontlineMarginFactor + continentBonus));
+        };
+    }
+
+    @Override
+    int simulateGame(ActionNode explorationNode) {
+        var currentNode = explorationNode;
+        while (true) {
+            if (currentNode.getSuccessors() == null) {
+                // expand further
+                getSuccessors(currentNode);
+            }
+            if (currentNode.getSuccessors().isEmpty()) {
+                // no further expansion possible
+                break;
+            }
+            currentNode = getNodeSelectionFunction().apply(currentNode);
+        }
+        return getEvaluationFunction().apply(currentNode);
+    }
+
+    /**
+     * reuses the static attack action supplier
+     * valid attack actions are:
+     *  - only with expected win chances > 0.5
+     *  - all-out-attacks ( no reason to attack with less than 3 troops if more is possible)
+     * @param selectedNode
+     * @return
+     */
+    @Override
+    List<ActionNode> getSuccessors(ActionNode selectedNode) {
+        if (selectedNode.getSuccessors() != null) {
+            return selectedNode.getSuccessors();
+        }
+        if (selectedNode.isLeafNode()) {
+            selectedNode.setSuccessors(new ArrayList<>());
+            return new ArrayList<>();
+        }
+
+        List<ActionNode> successors;
+        if (selectedNode.getGame().getBoard().isOccupyPhase()) {
+            // if we simulated the attack action we pass it to the action supplier - otherwise we fetch it from the history (takes more time)
+            Set<RiskAction> occupyActions = selectedNode.getAction() != null?
+                OccupyActionSupplier.createActions(selectedNode.getGame(), selectedNode.getAction()) :
+                    OccupyActionSupplier.createActions(selectedNode.getGame());
+
+            successors = occupyActions
+                        .stream()
+                        .map(ra -> new ActionNode(selectedNode.getPlayer(), selectedNode, applyActionToGame(selectedNode.getGame(), ra), ra))
+                        .collect(Collectors.toList());
+        } else {
+            successors = AttackActionSupplier
+                    .createActions(selectedNode.getGame(), MAX_ATTACK_TROOPS)
+                    .stream()
+                    .map(ra -> new ActionNode(selectedNode.getPlayer(), selectedNode, applyActionToGame(selectedNode.getGame(), ra), ra))
+                    .collect(Collectors.toList());
+            successors.add(new ActionNode(selectedNode.getPlayer(), selectedNode, applyActionToGame(selectedNode.getGame(), RiskAction.endPhase()), RiskAction.endPhase()));
+        }
+
+        selectedNode.setSuccessors(successors);
+
+        return successors;
+    }
+
+    /**
+     * attack is a multi-step action int the game engine
+     * @param game
+     * @param action
+     * @return
+     */
+    Risk applyActionToGame(Risk game, RiskAction action) {
+        if (action.isEndPhase() || game.getBoard().isOccupyPhase()) {
+            return (Risk) game.doAction(action);
+        }
+
+        // if attack is done we also need to simulate casualties which were also modelled as phase
+        game = (Risk) game.doAction(action); // attack
+        game = (Risk) game.doAction(Util.selectRandom(game.getPossibleActions())); // casualties are random
+        return game;
+    }
+}

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
@@ -73,7 +73,7 @@ public class AttackMctsActionSupplier extends MctsActionSupplier{
     @Override
     int simulateGame(ActionNode explorationNode) {
         var currentNode = explorationNode;
-        while (true) {
+        while (! this.shouldStopComputation.getAsBoolean()) {
             if (currentNode.getSuccessors() == null) {
                 // expand further
                 getSuccessors(currentNode);
@@ -106,7 +106,10 @@ public class AttackMctsActionSupplier extends MctsActionSupplier{
         }
 
         List<ActionNode> successors;
-        if (selectedNode.getGame().getBoard().isOccupyPhase()) {
+        if (selectedNode.getGame().isGameOver()) {
+            // no more actions
+            successors = List.of();
+        } else if (selectedNode.getGame().getBoard().isOccupyPhase()) {
             // if we simulated the attack action we pass it to the action supplier - otherwise we fetch it from the history (takes more time)
             Set<RiskAction> occupyActions = selectedNode.getAction() != null?
                 OccupyActionSupplier.createActions(selectedNode.getGame(), selectedNode.getAction()) :

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/AttackMctsActionSupplier.java
@@ -19,9 +19,11 @@ public class AttackMctsActionSupplier extends MctsActionSupplier{
      * magic numbers for optimal action selection
      */
     private static final double OCCUPATION_FACTOR = 20; // number of our occupied territories
-    private static final double FRONTLINE_PENALTY_FACTOR = -2; // number of enemy territories on the frontline
-    private static final double FRONTLINE_MARGIN_FACTOR = 0.25; // margin of frontline troops (ours minus theirs)
+    private static final double FRONTLINE_PENALTY_FACTOR = -.25; // number of enemy territories on the frontline
+    private static final double FRONTLINE_MARGIN_FACTOR = 0.75; // margin of frontline troops (ours minus theirs)
     private static final double CONTINENT_BONUS_FACTOR = 100; // bonus for occupied continents
+    private static final double ENEMY_CONTINENT_PENALTY_FACTOR = -40; // malus for enemy occupied continents
+    private static final double UNUSED_TROOPS_PENALTY_FACTOR = -0.5; // malus for inefficient attack/occupy
 
     private final static int MAX_ATTACK_TROOPS = 3;
 
@@ -60,8 +62,11 @@ public class AttackMctsActionSupplier extends MctsActionSupplier{
             double frontlineCntMalus = neighbouringEnemyTerritories.size() * FRONTLINE_PENALTY_FACTOR;
             double frontlineMarginFactor = GameUtils.getFrontlineMargin(occupiedTerritories, board) * FRONTLINE_MARGIN_FACTOR;
             double continentBonus = GameUtils.getContinentBonusForPlayer(activePlayer, board) * CONTINENT_BONUS_FACTOR;
+            double enemyContinentMalus = GameUtils.getTotalContinentMalus(activePlayer, board) * ENEMY_CONTINENT_PENALTY_FACTOR;
+            double unusedTroopsMalus = GameUtils.getUnusedTroops(occupiedTerritories, board) * UNUSED_TROOPS_PENALTY_FACTOR;
 
-            return Math.toIntExact(Math.round(occupationBonus + frontlineCntMalus + frontlineMarginFactor + continentBonus));
+            return Math.toIntExact(Math.round(occupationBonus + frontlineCntMalus +
+                    frontlineMarginFactor + continentBonus + enemyContinentMalus + unusedTroopsMalus));
         };
     }
 

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/MctsActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/MctsActionSupplier.java
@@ -1,0 +1,94 @@
+package at.ac.tuwien.ifs.sge.leeroy.mcts;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+public abstract class MctsActionSupplier {
+
+    protected ActionNode rootNode;
+    protected BooleanSupplier shouldStopComputation;
+
+    private static final Logger logger = Logger.getLogger(MctsActionSupplier.class.getName());
+
+    public MctsActionSupplier(BooleanSupplier shouldStopComputation) {
+        this.shouldStopComputation = shouldStopComputation;
+    }
+
+    abstract Function<ActionNode, ActionNode> getNodeSelectionFunction();
+
+    abstract Function<ActionNode, Integer> getEvaluationFunction();
+
+    abstract int simulateGame(ActionNode explorationNode);
+
+    abstract List<ActionNode> getSuccessors(ActionNode selectedNode);
+
+    public ActionNode findBestNode() {
+        performMcts();
+        if (rootNode.getSuccessors() == null) {
+            // stopped before execution (very slow pc or very low time)
+            logger.warning("No successors found - slow execution?");
+            return null;
+        }
+        return rootNode.getSuccessors().stream().max(Comparator.comparingDouble(ActionNode::getWinScore)).get();
+    }
+
+    private void performMcts() {
+        while (!this.shouldStopComputation.getAsBoolean()) {
+            var selectedNode = select();
+            var successors = getSuccessors(selectedNode); //expand
+            if (successors.isEmpty()) {
+                backpropagate(rootNode.getPlayer(), selectedNode, getEvaluationFunction().apply(selectedNode));
+            } else {
+                var explorationNode = getNodeSelectionFunction().apply(selectedNode);
+                int playOutResult = simulateGame(explorationNode);
+                backpropagate(rootNode.getPlayer(), explorationNode, playOutResult);
+            }
+        }
+    }
+
+    private ActionNode select() {
+        ActionNode bestNode = rootNode;
+        while (bestNode.isExpanded() && !bestNode.getSuccessors().isEmpty()) {
+            bestNode = findBestSuccessor(bestNode);
+        }
+        return bestNode;
+    }
+
+    private ActionNode findBestSuccessor(ActionNode node) {
+        var visited = node.getVisitCount();
+        return Collections.max(node.getSuccessors(), Comparator.comparingDouble(nodeA -> getUCTValue(visited, nodeA)));
+    }
+
+    protected double getUCTValue(int parentVisited, ActionNode node) {
+        if (node.getVisitCount() == 0) {
+            return Integer.MAX_VALUE;
+        } else {
+            return (node.getWinScore() / node.getVisitCount()) + 1.414 * Math.sqrt(Math.log(parentVisited) / node.getVisitCount());
+        }
+    }
+
+    private void backpropagate(int player, ActionNode explorationNode, int playOutResult) {
+        var toUpdate = Optional.of(explorationNode);
+        while (toUpdate.isPresent()) {
+            var nodeToUpdate = toUpdate.get();
+            nodeToUpdate.incrementVisitCount();
+            if (nodeToUpdate.getPlayer() == player) {
+                nodeToUpdate.incrementWinScore(playOutResult);
+            }
+            toUpdate = nodeToUpdate.getParent();
+        }
+    }
+
+    public ActionNode getRootNode() {
+        return rootNode;
+    }
+
+    public void setRootNode(ActionNode rootNode) {
+        this.rootNode = rootNode;
+    }
+}

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/util/game/TransparentRisk.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/util/game/TransparentRisk.java
@@ -57,7 +57,7 @@ public class TransparentRisk extends Risk {
                     getGame().getActionRecords().size() + ":\t" +
                             "Player: " + activePlayer + " Next action: " +
                     toReadableAction(riskAction, getBoard()) + "\n" +
-                    getGame().toTextRepresentation());
+                            (shouldPrintMap(riskAction, getBoard()) ? getGame().toTextRepresentation() : ""));
         }
 
         return new TransparentRisk((Risk) super.doAction(riskAction), this.gameName);
@@ -117,8 +117,8 @@ public class TransparentRisk extends Risk {
         if (action == null) {
             return "Start";
         }
-        if (action.attackingId() == -2) {
-            return "End of at.ac.tuwien.ifs.sge.leeroy.phase";
+        if (action.attackingId() == -2 && ! board.isOccupyPhase()) {
+            return "End of phase";
         }
         if (action.defendingId() == -3) {
             //??
@@ -142,5 +142,10 @@ public class TransparentRisk extends Risk {
                     TerritoryNames.of(action.defendingId()), action.troops());
         }
         return action.toString();
+    }
+
+    private boolean shouldPrintMap(RiskAction action, RiskBoard board) {
+        return (board.isAttackPhase() && action.attackingId() != -1) || board.isFortifyPhase()
+                || board.isReinforcementPhase();
     }
 }


### PR DESCRIPTION
Added MCTS for Attack & Occupy Actions:  

Features:

- reuses AttackActionSupplier & BattleSimulator to only consider attack action with an expected success > 0.5
- Simulates 1 Full Attack-Cycle (e.g. until next player becomes active)
- uses 6 magic numbers for evaluation function in AttackMctsActionSupplier (see explanation there)
- introduces OccupyActionSupplier which harshly reduces the search space for occupy-actions

Possible extensions:  

- optimize magic numbers
- reduce success-threshold at AttackActionSupplier to extend search space
- Add other phases to simulation (i.e. attacks of enemy)
- Extend evaluation function (e.g. penalize troop distance to frontline,...)

Simulation results (10 matches per setting):    
|  Setting | Win-Ratio | Nr. of Turns (mean +- std) |
| --------  | ----------- | ----------------------------- |
| new vs Random | 1.0 | 400 +- 62 |
| new vs alphabeta | 1.0 | 405 +- 126 |
| new vs mcts | 1.0 | 504 +- 176 |
| new vs leeroy | 0.2 | 531 +- 270 |
| leeroy vs new | 0.8 | 718 +- 407 |

i.e. the new version beats all dummy agents in every game but is beaten by the previous greedy attack leeroy agent in 8 out of 10 games (if set as first player). If set as second player it is beaten in only 2 out of 10 games.
Manual anaylsis has shown that the reason is to be found int the reinforce logic, which nearly always places all troops on a single territory. This leads to a high advance for the first attacker (i.e. second player) which can sweep roughly 70% of the board.
Please merge this changes into master and then try to either incooperate the reinforcement logic to my added mcts logic or build a better heuristic. Probably best if we have a short call in the next few days.
