### PR TITLE
Mcts Caching

### DIFF
--- a/src/main/java/GameSimulator.java
+++ b/src/main/java/GameSimulator.java
@@ -1,6 +1,7 @@
 import at.ac.tuwien.ifs.sge.agent.alphabetaagent.AlphaBetaAgent;
 import at.ac.tuwien.ifs.sge.agent.mctsagent.MctsAgent;
 import at.ac.tuwien.ifs.sge.agent.randomagent.RandomAgent;
+import at.ac.tuwien.ifs.sge.leeroy.agents.CachedMctsLeeroy;
 import at.ac.tuwien.ifs.sge.leeroy.agents.Leeroy;
 import at.ac.tuwien.ifs.sge.leeroy.agents.LeeroyMctsAttack;
 import at.ac.tuwien.ifs.sge.leeroy.util.command.MockedMatchCommand;
@@ -17,8 +18,8 @@ public class GameSimulator {
         for (int i = 1; i< 11; i++) {
             System.out.println(String.format("Performing run %d", i));
             MockedMatchCommand mCmd = new MockedMatchCommand(String.format("GameRun_%02d", i));
-            mCmd.setEvaluatedAgent(LeeroyMctsAttack.class);
-            mCmd.setOpponentAgent(AlphaBetaAgent.class);
+            mCmd.setEvaluatedAgent(CachedMctsLeeroy.class);
+            mCmd.setOpponentAgent(Leeroy.class);
             mCmd.showMapOutput(false);
             mCmd.setComputationTime(15l); // max seconds per turn
 

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/CachedMctsLeeroy.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/CachedMctsLeeroy.java
@@ -1,0 +1,66 @@
+package at.ac.tuwien.ifs.sge.leeroy.agents;
+
+import at.ac.tuwien.ifs.sge.engine.Logger;
+import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.ActionNode;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.AttackMctsActionSupplier;
+import at.ac.tuwien.ifs.sge.leeroy.mcts.MctsActionSupplier;
+import at.ac.tuwien.ifs.sge.util.Util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * adds a cached mcts tree which reuses searches from previous simulation runs
+ */
+public class CachedMctsLeeroy extends LeeroyMctsAttack{
+
+    private List<ActionNode> simulationSuccessors = new ArrayList<>();
+
+    public CachedMctsLeeroy(Logger log) {
+        super(log);
+    }
+
+    @Override
+    protected RiskAction attackTerritory(Risk risk) {
+        return this.performAction(risk, 1);
+    }
+
+    @Override
+    protected RiskAction occupyTerritory(Risk risk) {
+        return this.performAction(risk, 2);
+    }
+
+    protected RiskAction performAction(Risk risk, int timeoutPenalty) {
+        MctsActionSupplier actionSupplier = new AttackMctsActionSupplier(
+                () -> this.shouldStopComputation(timeoutPenalty));
+        actionSupplier.setRootNode(getRootNode(risk));
+        ActionNode bestNode = actionSupplier.findBestNode();
+        if (bestNode != null) {
+            simulationSuccessors = bestNode.getSuccessors();
+            return bestNode.getAction();
+        }
+        // mcts stopped before any node was evaluated - mostly caused by instable opponent agents
+        simulationSuccessors = new ArrayList<>();
+        return Util.selectRandom(risk.getPossibleActions());
+    }
+
+    /**
+     * choose root node for mcts
+     * tries to reuse successors from previous simulation run(s), if non exist creates new root
+     * @return
+     */
+    protected ActionNode getRootNode(Risk game) {
+        RiskAction lastAction = game.getPreviousAction();
+        ActionNode defaultRoot = new ActionNode(game.getCurrentPlayer(), null, game, null);
+        if (lastAction == null || simulationSuccessors.isEmpty()) {
+            return defaultRoot;
+        }
+        return simulationSuccessors
+                .stream()
+                .filter(simNode -> simNode.getAction().equals(lastAction))
+                .findFirst()
+                .orElse(defaultRoot);
+    }
+}

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
@@ -13,8 +13,6 @@ import at.ac.tuwien.ifs.sge.util.Util;
  */
 public class LeeroyMctsAttack extends Leeroy {
 
-    // TODO: store/reuse search tree from previous mcts runs
-
     private final int ATTACK_TIMEOUT_PENALTY = 1;
     private final int OCCUPY_TIMEOUT_PENALTY = 2;
 


### PR DESCRIPTION
Had time for a quick improvement.  
New features:

- reuse previous simulation runs (simple logic which just compares actions of all successors with actually executed action, i.e. only affects casualities)
- now each possible attack-outcome (i.e. casualties) represents a branch/successor - before all were merged together

Possible extensions:

- mcts reusage after opponent played their turn - would require an efficient method to check board similarity/equality
- mcts exploration for all casualties - atm we explore mostly the best-case scenario (as fewer losses lead to higher value for evaluation function). While mcts-simulation chooses a random successor for the casualty-phase, this is trickier for exploration (and I'm not sure if a change would give a lot of benefits..)