### PR TITLE
Cache RiskGame.getBoard() calls

### DIFF
--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/AttackActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/AttackActionSupplier.java
@@ -2,6 +2,7 @@ package at.ac.tuwien.ifs.sge.leeroy.agents;
 
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -10,24 +11,22 @@ public class AttackActionSupplier {
 
     private static final double RISK_THRESHOLD = 0.5;
 
-    public static Set<RiskAction> createActions(Risk risk, Integer maxAttackerCnt) {
-        final Set<Integer> sourceTerritoryIds = risk
-                .getBoard()
+    public static Set<RiskAction> createActions(Risk risk, RiskBoard board, Integer maxAttackerCnt) {
+        final Set<Integer> sourceTerritoryIds = board
                 .getTerritoriesOccupiedByPlayer(risk.getCurrentPlayer());
         var attackActions = sourceTerritoryIds
               .stream()
-              .flatMap(tId -> AttackActionSupplier.createActions(risk, tId, maxAttackerCnt).stream())
+              .flatMap(tId -> AttackActionSupplier.createActions(risk, board, tId, maxAttackerCnt).stream())
               .collect(Collectors.toSet());
         return attackActions;
     }
 
-    private static Set<RiskAction> createActions(Risk risk, Integer srcTerritoryId, Integer maxAttackerCnt) {
-        final Set<Integer> targetTerritoryIds = risk
-                .getBoard()
+    private static Set<RiskAction> createActions(Risk risk, RiskBoard board, Integer srcTerritoryId, Integer maxAttackerCnt) {
+        final Set<Integer> targetTerritoryIds = board
                 .neighboringEnemyTerritories(srcTerritoryId);
         return targetTerritoryIds
                 .stream()
-                .flatMap(tId -> AttackActionSupplier.createActions(risk, srcTerritoryId, tId, maxAttackerCnt).stream())
+                .flatMap(tId -> AttackActionSupplier.createActions(risk, board, srcTerritoryId, tId, maxAttackerCnt).stream())
                 .collect(Collectors.toSet());
     }
 
@@ -38,9 +37,9 @@ public class AttackActionSupplier {
      * @param targetTerritoryId
      * @return
      */
-    private static Set<RiskAction> createActions(Risk risk, Integer srcTerritoryId, Integer targetTerritoryId, Integer maxAttackerCnt) {
-        int maxAttackTroops = risk.getBoard().getMobileTroops(srcTerritoryId);
-        final int defenderTroops = risk.getBoard().getTerritoryTroops(targetTerritoryId);
+    private static Set<RiskAction> createActions(Risk risk, RiskBoard board, Integer srcTerritoryId, Integer targetTerritoryId, Integer maxAttackerCnt) {
+        int maxAttackTroops = board.getMobileTroops(srcTerritoryId);
+        final int defenderTroops = board.getTerritoryTroops(targetTerritoryId);
 
         if (BattleSimulator.getWinProbability(maxAttackTroops, defenderTroops) >= RISK_THRESHOLD) {
             maxAttackTroops = maxAttackerCnt != null ? Math.min(maxAttackTroops, maxAttackerCnt) : maxAttackTroops; // return only valid attacks

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/CachedMctsLeeroy.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/CachedMctsLeeroy.java
@@ -3,6 +3,7 @@ package at.ac.tuwien.ifs.sge.leeroy.agents;
 import at.ac.tuwien.ifs.sge.engine.Logger;
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.ActionNode;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.AttackMctsActionSupplier;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.MctsActionSupplier;
@@ -27,7 +28,7 @@ public class CachedMctsLeeroy extends LeeroyMctsAttack {
     }
 
     @Override
-    protected RiskAction attackTerritory(Risk risk) {
+    protected RiskAction attackTerritory(Risk risk, RiskBoard riskBoard) {
         return this.performAction(risk, ATTACK_TIMEOUT_PENALTY);
     }
 

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/GameUtils.java
@@ -32,9 +32,8 @@ public class GameUtils {
         }
     }
 
-    public static List<Map.Entry<Integer, RiskTerritory>> getUnoccupiedEntries(Risk risk) {
-        return risk
-                .getBoard()
+    public static List<Map.Entry<Integer, RiskTerritory>> getUnoccupiedEntries(RiskBoard board) {
+        return board
                 .getTerritories()
                 .entrySet()
                 .stream()
@@ -42,9 +41,8 @@ public class GameUtils {
                 .collect(Collectors.toList());
     }
 
-    public static List<Map.Entry<Integer, RiskTerritory>> getOccupiedEntries(Risk risk) {
-        return risk
-                .getBoard()
+    public static List<Map.Entry<Integer, RiskTerritory>> getOccupiedEntries(RiskBoard board) {
+        return board
                 .getTerritories()
                 .entrySet()
                 .stream()
@@ -52,20 +50,19 @@ public class GameUtils {
                 .collect(Collectors.toList());
     }
 
-    public static Function<Node, Integer> partialInitialEvaluationFunction(Risk risk) {
-        return (node) -> evaluateInitialBoard(node, risk);
+    public static Function<Node, Integer> partialInitialEvaluationFunction(Risk risk, RiskBoard board) {
+        return (node) -> evaluateInitialBoard(node, risk, board);
     }
 
-    private static Integer evaluateInitialBoard(Node node, Risk risk) {
+    private static Integer evaluateInitialBoard(Node node, Risk risk, RiskBoard board) {
         if (node.getSuccessors().isEmpty()) {
             int playerId = risk.getCurrentPlayer();
-            RiskBoard riskBoard = risk.getBoard();
             Set<Integer> territoriesOccupiedByPlayer = getTerritoriesOccupiedByPlayer(playerId, ((InitialPlacementNode) node).getOccupiedTerritories());
-            Set<Set<Integer>> areas = getAreas(territoriesOccupiedByPlayer, riskBoard);
-            int totalNumberOfNeighbors = getNeighbors(territoriesOccupiedByPlayer, riskBoard).size();
-            int numberOfContinentsOccupied = getContinentsOccupied(territoriesOccupiedByPlayer, riskBoard).size();
-            int totalContinentBonus = getTotalContinentBonus(playerId, riskBoard);
-            int totalContinentMalus = getTotalContinentMalus(playerId, riskBoard);
+            Set<Set<Integer>> areas = getAreas(territoriesOccupiedByPlayer, board);
+            int totalNumberOfNeighbors = getNeighbors(territoriesOccupiedByPlayer, board).size();
+            int numberOfContinentsOccupied = getContinentsOccupied(territoriesOccupiedByPlayer, board).size();
+            int totalContinentBonus = getTotalContinentBonus(playerId, board);
+            int totalContinentMalus = getTotalContinentMalus(playerId, board);
             return -1 * areas.size()
                     * totalNumberOfNeighbors
                     * numberOfContinentsOccupied
@@ -199,15 +196,14 @@ public class GameUtils {
                         Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
     }
 
-    public static Function<Node, Node> partialInitialExpansionFunction(Risk game) {
-        return (node) -> initialExpansionFunction(node, game);
+    public static Function<Node, Node> partialInitialExpansionFunction(RiskBoard riskBoard) {
+        return (node) -> initialExpansionFunction(node, riskBoard);
     }
 
-    private static Node initialExpansionFunction(Node node, Risk game) {
-        var board = game.getBoard();
+    private static Node initialExpansionFunction(Node node, RiskBoard riskBoard) {
         return Collections.min(node.getSuccessors(),
                 Comparator.comparingInt(nodeToEvaluate ->
-                        getAreas(board.getTerritoriesOccupiedByPlayer(nodeToEvaluate.getPlayer()), board).size()));
+                        getAreas(riskBoard.getTerritoriesOccupiedByPlayer(nodeToEvaluate.getPlayer()), riskBoard).size()));
     }
 
     public static boolean isReinforcementAction(RiskAction riskAction) {

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/HeuristicReinforce.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/HeuristicReinforce.java
@@ -2,6 +2,7 @@ package at.ac.tuwien.ifs.sge.leeroy.agents;
 
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskTerritory;
 import at.ac.tuwien.ifs.sge.util.Util;
 import org.javatuples.Pair;
@@ -20,8 +21,7 @@ public class HeuristicReinforce {
     private static final Logger logger = Logger.getLogger(HeuristicReinforce.class.getName());
 
 
-    public static RiskAction reinforce(int playerNumber, Risk game) {
-        var board = game.getBoard();
+    public static RiskAction reinforce(int playerNumber, Risk game, RiskBoard board) {
         var possibleActions = game.getPossibleActions();
 
         var playerUnitsOnContinent = board

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/Leeroy.java
@@ -38,20 +38,21 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
 
         log.info("Computing action");
         Risk risk = (Risk) game;
+        RiskBoard board = risk.getBoard();
         A nextAction;
         try {
-            setPhase(game.getBoard());
+            setPhase(board);
             if (currentPhase == Phase.INITIAL_SELECT) {
-                setNewInitialPlacementRoot(risk);
-                nextAction = (A) selectInitialCountry(risk);
-            } else if (game.getBoard().isReinforcementPhase()) {
-                nextAction = (A) reinforce(risk);
-            } else if (game.getBoard().isAttackPhase()) {
-                nextAction = (A) attackTerritory(risk);
-            } else if (game.getBoard().isOccupyPhase()) {
+                setNewInitialPlacementRoot(risk, board);
+                nextAction = (A) selectInitialCountry(risk, board);
+            } else if (board.isReinforcementPhase()) {
+                nextAction = (A) reinforce(risk, board);
+            } else if (board.isAttackPhase()) {
+                nextAction = (A) attackTerritory(risk, board);
+            } else if (board.isOccupyPhase()) {
                 nextAction = (A) occupyTerritory(risk);
-            } else if (game.getBoard().isFortifyPhase()) {
-                nextAction = (A) fortifyTerritory(risk);
+            } else if (board.isFortifyPhase()) {
+                nextAction = (A) fortifyTerritory(risk, board);
             } else {
                 nextAction = (A) Util.selectRandom(risk.getPossibleActions());
             }
@@ -84,22 +85,22 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         }
     }
 
-    private RiskAction selectInitialCountry(Risk game) {
+    private RiskAction selectInitialCountry(Risk game, RiskBoard board) {
         //Graph moved one node forward after the action
-        initialPlacementRoot = searchBestNode(initialPlacementRoot, GameUtils.partialInitialExpansionFunction(game), GameUtils.partialInitialEvaluationFunction(game));
+        initialPlacementRoot = searchBestNode(initialPlacementRoot, GameUtils.partialInitialExpansionFunction(board), GameUtils.partialInitialEvaluationFunction(game, board));
         return RiskAction.select(initialPlacementRoot.getId());
     }
 
-    protected RiskAction reinforce(Risk game) {
-        if (hasToTradeInCards(game)) {
+    protected RiskAction reinforce(Risk game, RiskBoard board) {
+        if (hasToTradeInCards(board)) {
             return tradeInCards(game);
         }
 
-        return HeuristicReinforce.reinforce(playerNumber, game);
+        return HeuristicReinforce.reinforce(playerNumber, game, board);
     }
 
-    private boolean hasToTradeInCards(Risk game) {
-        return game.getBoard().hasToTradeInCards(playerNumber);
+    private boolean hasToTradeInCards(RiskBoard board) {
+        return board.hasToTradeInCards(playerNumber);
     }
 
     private RiskAction tradeInCards(Risk game) {
@@ -115,11 +116,11 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         return node.getSuccessors().stream().max(Comparator.comparingDouble(Node::getWinScore)).get();
     }
 
-    protected RiskAction attackTerritory(Risk risk) {
-        Set<RiskAction> attackActions = AttackActionSupplier.createActions(risk, null);
+    protected RiskAction attackTerritory(Risk risk, RiskBoard board) {
+        Set<RiskAction> attackActions = AttackActionSupplier.createActions(risk, board, null);
         Optional<RiskAction> highAtkAction = attackActions
                 .stream()
-                .sorted(Comparator.comparingInt(action -> action.troops() *-1))
+                .sorted(Comparator.comparingInt(action -> action.troops() * -1))
                 .findFirst();
         if (highAtkAction.isPresent()) {
             RiskAction atkAction = highAtkAction.get();
@@ -132,27 +133,27 @@ public class Leeroy<G extends Game<A, RiskBoard>, A> extends AbstractGameAgent<G
         return RiskAction.occupy(risk.getPossibleActions().size());
     }
 
-    private RiskAction fortifyTerritory(Risk risk) {
+    private RiskAction fortifyTerritory(Risk risk, RiskBoard board) {
         // TODO: MCTS
-        Set<RiskAction> fortificationActions = FortificationActionSupplier.createActions(risk);
+        Set<RiskAction> fortificationActions = FortificationActionSupplier.createActions(risk, board);
         Optional<RiskAction> bestAction = fortificationActions
                 .stream()
-                .sorted(Comparator.comparingInt(action -> action.troops() *-1))
+                .sorted(Comparator.comparingInt(action -> action.troops() * -1))
                 .findFirst();
         return bestAction.orElse(RiskAction.endPhase()); // if no action was found we just end the at.ac.tuwien.ifs.sge.leeroy.phase
     }
 
-    private void setNewInitialPlacementRoot(Risk game) {
+    private void setNewInitialPlacementRoot(Risk game, RiskBoard board) {
         if (this.initialPlacementRoot == null) {
             log.info(Phase.INITIAL_SELECT);
             this.initialPlacementRoot = new InitialPlacementNode((game.getCurrentPlayer() + 1) % 2,
                     -1,
                     null,
-                    GameUtils.getOccupiedEntries(game),
-                    GameUtils.getUnoccupiedEntries(game));
+                    GameUtils.getOccupiedEntries(board),
+                    GameUtils.getUnoccupiedEntries(board));
         } else {
 
-            var occupiedEntries = GameUtils.getOccupiedEntries(game);
+            var occupiedEntries = GameUtils.getOccupiedEntries(board);
             initialPlacementRoot = initialPlacementRoot
                     .getSuccessors()
                     .stream()

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/LeeroyMctsAttack.java
@@ -3,6 +3,7 @@ package at.ac.tuwien.ifs.sge.leeroy.agents;
 import at.ac.tuwien.ifs.sge.engine.Logger;
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.ActionNode;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.AttackMctsActionSupplier;
 import at.ac.tuwien.ifs.sge.leeroy.mcts.MctsActionSupplier;
@@ -22,7 +23,7 @@ public class LeeroyMctsAttack extends Leeroy {
     }
 
     @Override
-    protected RiskAction reinforce(Risk risk) {
+    protected RiskAction reinforce(Risk risk, RiskBoard board) {
         MctsActionSupplier actionSupplier = new AttackMctsActionSupplier(
                 () -> this.shouldStopComputation(REINFORCE_TIMEOUT_PENALTY));
         actionSupplier.setRootNode(new ActionNode(risk.getCurrentPlayer(), null, risk, null));
@@ -31,7 +32,7 @@ public class LeeroyMctsAttack extends Leeroy {
     }
 
     @Override
-    protected RiskAction attackTerritory(Risk risk) {
+    protected RiskAction attackTerritory(Risk risk, RiskBoard board) {
         MctsActionSupplier actionSupplier = new AttackMctsActionSupplier(
                 () -> this.shouldStopComputation(ATTACK_TIMEOUT_PENALTY));
         actionSupplier.setRootNode(new ActionNode(risk.getCurrentPlayer(), null, risk, null));

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/OccupyActionSupplier.java
@@ -3,58 +3,59 @@ package at.ac.tuwien.ifs.sge.leeroy.agents;
 import at.ac.tuwien.ifs.sge.game.ActionRecord;
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 
 import java.util.HashSet;
 import java.util.Set;
 
 public class OccupyActionSupplier {
 
-    public static Set<RiskAction> createActions(Risk risk) {
+    public static Set<RiskAction> createActions(Risk risk, RiskBoard riskBoard) {
         int attackActionId = risk.getNumberOfActions() - 2;
         ActionRecord attackRecord = risk.getActionRecords().get(attackActionId);
         RiskAction attackAction = (RiskAction)attackRecord.getAction();
 
-        return createActions(risk, attackAction);
+        return createActions(risk, riskBoard, attackAction);
     }
 
-    public static Set<RiskAction> createActions(Risk risk, RiskAction attackAction) {
+    public static Set<RiskAction> createActions(Risk risk, RiskBoard riskBoard, RiskAction attackAction) {
         int srcTerritory = attackAction.attackingId();
         int targetTerritory = attackAction.defendingId();
 
-        Set<Integer> srcEnemyNeighbors = risk.getBoard().neighboringEnemyTerritories(srcTerritory);
-        Set<Integer> targetEnemyNeighbors = risk.getBoard().neighboringEnemyTerritories(targetTerritory);
+        Set<Integer> srcEnemyNeighbors = riskBoard.neighboringEnemyTerritories(srcTerritory);
+        Set<Integer> targetEnemyNeighbors = riskBoard.neighboringEnemyTerritories(targetTerritory);
         boolean isSrcSafe = srcEnemyNeighbors.isEmpty();
         boolean isTargetSafe = targetEnemyNeighbors.isEmpty();
 
         if (isTargetSafe && ! isSrcSafe) {
             return Set.of(RiskAction.occupy(1)); // min troops
         } else if (isSrcSafe && ! isTargetSafe) {
-            return Set.of(RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))); // max troops
+            return Set.of(RiskAction.occupy(riskBoard.getFortifyableTroops(srcTerritory))); // max troops
         }
 
         if (isTargetSafe && isSrcSafe) {
             // if none of the territories is at the frontline - check which is closer
-            int srcFrontlineDistance = getFrontlineDistance(risk, srcTerritory);
-            int targetFrontlineDistance = getFrontlineDistance(risk, targetTerritory);
+            int srcFrontlineDistance = getFrontlineDistance(risk, riskBoard, srcTerritory);
+            int targetFrontlineDistance = getFrontlineDistance(risk, riskBoard, targetTerritory);
 
             if (srcFrontlineDistance < targetFrontlineDistance) {
                 return Set.of(RiskAction.occupy(1)); // min troops
             } else if (srcFrontlineDistance > targetFrontlineDistance) {
-                return Set.of(RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))); // max troops
+                return Set.of(RiskAction.occupy(riskBoard.getFortifyableTroops(srcTerritory))); // max troops
             }
             // if distance is equal let mcts decide
             return Set.of(
                     RiskAction.occupy(1),
-                    RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory)));
+                    RiskAction.occupy(riskBoard.getFortifyableTroops(srcTerritory)));
         }
 
         // both are frontline: evaluate - move all, move min, move according to territory ratio
         Set<RiskAction> evaluatedActions = new HashSet<>(Set.of(
                 RiskAction.occupy(1),
-                RiskAction.occupy(risk.getBoard().getFortifyableTroops(srcTerritory))));
+                RiskAction.occupy(riskBoard.getFortifyableTroops(srcTerritory))));
 
         double targetFrontlineTerritoryRatio = targetEnemyNeighbors.size() * 1.0 / (targetEnemyNeighbors.size() + srcEnemyNeighbors.size());
-        long occupyTroops = Math.round(risk.getBoard().getFortifyableTroops(srcTerritory) * targetFrontlineTerritoryRatio);
+        long occupyTroops = Math.round(riskBoard.getFortifyableTroops(srcTerritory) * targetFrontlineTerritoryRatio);
         if (occupyTroops > 1) {
             evaluatedActions.add(RiskAction.occupy((int) occupyTroops));
         }
@@ -68,7 +69,7 @@ public class OccupyActionSupplier {
      * @param sourceTerritory
      * @return
      */
-    private static int getFrontlineDistance(Risk risk, int sourceTerritory) {
+    private static int getFrontlineDistance(Risk risk, RiskBoard riskBoard, int sourceTerritory) {
         Set<Integer> curLevelTerritories = Set.of(sourceTerritory);
         Set<Integer> evaluatedTerritories = new HashSet<>();
         Set<Integer> nextLevelTerritories;
@@ -76,11 +77,11 @@ public class OccupyActionSupplier {
         while (!curLevelTerritories.isEmpty()) {
             nextLevelTerritories = new HashSet<>();
             for (Integer srcId : curLevelTerritories) {
-                if (! risk.getBoard().neighboringEnemyTerritories(srcId).isEmpty()) {
+                if (! riskBoard.neighboringEnemyTerritories(srcId).isEmpty()) {
                     return curDistance;
                 }
                 evaluatedTerritories.add(srcId);
-                Set<Integer> newNeighbors = risk.getBoard().neighboringFriendlyTerritories(srcId);
+                Set<Integer> newNeighbors = riskBoard.neighboringFriendlyTerritories(srcId);
                 newNeighbors.removeAll(evaluatedTerritories);
                 newNeighbors.removeAll(curLevelTerritories);
                 nextLevelTerritories.addAll(newNeighbors);

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/ReinforcementActionSupplier.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/agents/ReinforcementActionSupplier.java
@@ -24,7 +24,9 @@ public class ReinforcementActionSupplier {
         var validActions = game.getPossibleActions();
         var tradeInActions = validActions.stream()
                 .filter(RiskAction::isCardIds);
-        if (tradeInActions.count() == validActions.size()) {
+        // We can not use tradeInActions.count(), since this closes the stream)
+        var onlyTradeInActions = validActions.stream().allMatch(RiskAction::isCardIds);
+        if (onlyTradeInActions) {
             //We have to trade in
             return tradeInActions;
         } else {

--- a/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/ActionNode.java
+++ b/src/main/java/at/ac/tuwien/ifs/sge/leeroy/mcts/ActionNode.java
@@ -2,6 +2,7 @@ package at.ac.tuwien.ifs.sge.leeroy.mcts;
 
 import at.ac.tuwien.ifs.sge.game.risk.board.Risk;
 import at.ac.tuwien.ifs.sge.game.risk.board.RiskAction;
+import at.ac.tuwien.ifs.sge.game.risk.board.RiskBoard;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,16 +10,24 @@ import java.util.List;
 import java.util.Optional;
 
 @Getter
-@RequiredArgsConstructor
 public class ActionNode {
 
     private final int player;
     private final ActionNode parent;
     private final Risk game;
+    private final RiskBoard board;
     private final RiskAction action;
     private List<ActionNode> successors = null;
     private double winScore;
     private int visitCount = 0;
+
+    public ActionNode(int player, ActionNode parent, Risk game, RiskAction action) {
+        this.player = player;
+        this.parent = parent;
+        this.game = game;
+        this.board = game.getBoard();
+        this.action = action;
+    }
 
     public List<ActionNode> getSuccessors() {
         return successors;


### PR DESCRIPTION
RiskGame.getBoard() is a very expensive operation. As I found out
through profiling, it is called very often and takes up so much
resources we run into an OOM exception. In this branch, I try to cache
RiskGame.getBoard() as greedy as possible. As a result, a full game now
can be played.
This commit also contains one small fix where we tried to access a
closed stream.